### PR TITLE
Support failed publish response

### DIFF
--- a/src/Confluent.RestClient/Model/OffSet.cs
+++ b/src/Confluent.RestClient/Model/OffSet.cs
@@ -8,13 +8,13 @@ namespace Confluent.RestClient.Model
         /// Partition the message was published to, or null if publishing the message failed
         /// </summary>
         [JsonProperty(PropertyName = "partition")]
-        public int PartitionId { get; set; }
+        public int? PartitionId { get; set; }
 
         /// <summary>
         /// Offset of the message, or null if publishing the message failed
         /// </summary>
         [JsonProperty(PropertyName = "offset")]
-        public long Offset { get; set; }
+        public long? Offset { get; set; }
 
         /// <summary>
         /// An error code classifying the reason this operation failed, or null if it succeeded.
@@ -23,5 +23,11 @@ namespace Confluent.RestClient.Model
         /// </summary>
         [JsonProperty(PropertyName = "error_code")]
         public long? ErrorCode { get; set; }
+
+        /// <summary>
+        /// An error message describing the reason this operation failed, or null if it succeeded.
+        /// </summary>
+        [JsonProperty(PropertyName = "error")]
+        public string Error { get; set; }
     }
 }


### PR DESCRIPTION
Support failed publish that returns null for partition & offset

This is the exception that was encountered that prompted this change:

```
Confluent.RestClient.Exceptions.ConfluentApiSerializationException:
Failed to deserialize response --->
Newtonsoft.Json.JsonSerializationException: Error converting value
{null} to type 'System.Int32'. Path 'offsets[0].partition', line 1,
position 29. ---> System.InvalidCastException: Null object cannot be
converted to a value type.
at System.Convert.ChangeType(Object value, Type conversionType,
IFormatProvider provider)
```
