### PR TITLE
Support for cancellation and explicit disregard of callback context

### DIFF
--- a/src/Confluent.RestClient/ConfluentClient.cs
+++ b/src/Confluent.RestClient/ConfluentClient.cs
@@ -164,12 +164,21 @@ namespace Confluent.RestClient
         public async Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
             ConsumerInstance consumerInstance,
             string topic,
-            int? maxBytes)
+            int maxBytes)
         {
             return await ConsumeAsBinaryAsync(consumerInstance, topic, maxBytes, CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
+            ConsumerInstance consumerInstance,
+            string topic,
+            int maxBytes,
+            CancellationToken cancellationToken)
+        {
+            return await ConsumeAsBinaryAsync(consumerInstance, topic, maxBytes as int?, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private async Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
             ConsumerInstance consumerInstance,
             string topic,
             int? maxBytes,
@@ -206,7 +215,7 @@ namespace Confluent.RestClient
         public async Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
             ConsumerInstance consumerInstance,
             string topic,
-            int? maxBytes)
+            int maxBytes)
             where TKey : class
             where TValue : class
         {
@@ -214,6 +223,17 @@ namespace Confluent.RestClient
         }
 
         public async Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
+            ConsumerInstance consumerInstance,
+            string topic,
+            int maxBytes,
+            CancellationToken cancellationToken)
+            where TKey : class
+            where TValue : class
+        {
+            return await ConsumeAsAvroAsync<TKey, TValue>(consumerInstance, topic, maxBytes as int?, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private async Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
             ConsumerInstance consumerInstance,
             string topic,
             int? maxBytes,

--- a/src/Confluent.RestClient/ConfluentClient.cs
+++ b/src/Confluent.RestClient/ConfluentClient.cs
@@ -148,17 +148,32 @@ namespace Confluent.RestClient
 
         public async Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
             ConsumerInstance consumerInstance,
-            string topic,
-            int? maxBytes = null)
+            string topic)
         {
-            return await ConsumeAsBinaryAsync(consumerInstance, topic, CancellationToken.None, maxBytes).ConfigureAwait(false);
+            return await ConsumeAsBinaryAsync(consumerInstance, topic, null, CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
             ConsumerInstance consumerInstance,
             string topic,
-            CancellationToken cancellationToken,
-            int? maxBytes = null)
+            CancellationToken cancellationToken)
+        {
+            return await ConsumeAsBinaryAsync(consumerInstance, topic, null, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
+            ConsumerInstance consumerInstance,
+            string topic,
+            int? maxBytes)
+        {
+            return await ConsumeAsBinaryAsync(consumerInstance, topic, maxBytes, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
+            ConsumerInstance consumerInstance,
+            string topic,
+            int? maxBytes,
+            CancellationToken cancellationToken)
         {
             string requestUri = BuildConsumeRequestUri(topic, maxBytes);
 
@@ -171,19 +186,38 @@ namespace Confluent.RestClient
 
         public async Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
             ConsumerInstance consumerInstance,
-            string topic,
-            int? maxBytes = null)
+            string topic)
             where TKey : class
             where TValue : class
         {
-            return await ConsumeAsAvroAsync<TKey, TValue>(consumerInstance, topic, CancellationToken.None, maxBytes).ConfigureAwait(false);
+            return await ConsumeAsAvroAsync<TKey, TValue>(consumerInstance, topic, null, CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
             ConsumerInstance consumerInstance,
             string topic,
-            CancellationToken cancellationToken,
-            int? maxBytes = null)
+            CancellationToken cancellationToken)
+            where TKey : class
+            where TValue : class
+        {
+            return await ConsumeAsAvroAsync<TKey, TValue>(consumerInstance, topic, null, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
+            ConsumerInstance consumerInstance,
+            string topic,
+            int? maxBytes)
+            where TKey : class
+            where TValue : class
+        {
+            return await ConsumeAsAvroAsync<TKey, TValue>(consumerInstance, topic, maxBytes, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
+            ConsumerInstance consumerInstance,
+            string topic,
+            int? maxBytes,
+            CancellationToken cancellationToken)
             where TKey : class
             where TValue : class
         {

--- a/src/Confluent.RestClient/ConfluentClient.cs
+++ b/src/Confluent.RestClient/ConfluentClient.cs
@@ -20,7 +20,7 @@ namespace Confluent.RestClient
 
         private readonly HttpClient _client;
 
-        public ConfluentClient() 
+        public ConfluentClient()
             : this(new DefaultConfluentClientSettings())
         {
         }
@@ -28,57 +28,92 @@ namespace Confluent.RestClient
         public ConfluentClient(IConfluentClientSettings clientSettings)
         {
             _clientSettings = clientSettings;
-            _client = new HttpClient {Timeout = clientSettings.RequestTimeout};
+            _client = new HttpClient { Timeout = clientSettings.RequestTimeout };
         }
 
         public async Task<ConfluentResponse<List<string>>> GetTopicsAsync()
         {
+            return await GetTopicsAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<List<string>>> GetTopicsAsync(CancellationToken cancellationToken)
+        {
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Get, "/topics");
 
-            return await ProcessRequest<List<string>>(request);
+            return await ProcessRequest<List<string>>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ConfluentResponse<Topic>> GetTopicMetadataAsync(string topic)
         {
+            return await GetTopicMetadataAsync(topic, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<Topic>> GetTopicMetadataAsync(string topic, CancellationToken cancellationToken)
+        {
             string requestUri = string.Format("/topics/{0}", topic);
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Get, requestUri);
 
-            return await ProcessRequest<Topic>(request);
+            return await ProcessRequest<Topic>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ConfluentResponse<List<Partition>>> GetTopicPartitionsAsync(string topic)
         {
+            return await GetTopicPartitionsAsync(topic, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<List<Partition>>> GetTopicPartitionsAsync(string topic, CancellationToken cancellationToken)
+        {
             string requestUri = string.Format("/topics/{0}/partitions", topic);
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Get, requestUri);
 
-            return await ProcessRequest<List<Partition>>(request);
+            return await ProcessRequest<List<Partition>>(request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<ConfluentResponse<Partition>> GetTopicPartitionAsync(
-            string topic, 
-            int partitionId)
+        public async Task<ConfluentResponse<Partition>> GetTopicPartitionAsync(string topic, int partitionId)
+        {
+            return await GetTopicPartitionAsync(topic, partitionId, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<Partition>> GetTopicPartitionAsync(string topic, int partitionId, CancellationToken cancellationToken)
         {
             string requestUri = string.Format("/topics/{0}/partitions/{1}", topic, partitionId);
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Get, requestUri);
 
-            return await ProcessRequest<Partition>(request);
+            return await ProcessRequest<Partition>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ConfluentResponse<PublishResponse>> PublishAsBinaryAsync(
-            string topic, 
+            string topic,
             BinaryRecordSet recordSet)
+        {
+            return await PublishAsBinaryAsync(topic, recordSet, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<PublishResponse>> PublishAsBinaryAsync(
+            string topic,
+            BinaryRecordSet recordSet,
+            CancellationToken cancellationToken)
         {
             string requestUri = string.Format("/topics/{0}", topic);
 
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Post, requestUri)
                 .WithContent(recordSet, ContentTypeKafkaBinary);
 
-            return await ProcessRequest<PublishResponse>(request);
+            return await ProcessRequest<PublishResponse>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ConfluentResponse<PublishResponse>> PublishAsAvroAsync<TKey, TValue>(
-            string topic, 
+            string topic,
             AvroRecordSet<TKey, TValue> recordSet)
+            where TKey : class
+            where TValue : class
+        {
+            return await PublishAsAvroAsync(topic, recordSet, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<PublishResponse>> PublishAsAvroAsync<TKey, TValue>(
+            string topic,
+            AvroRecordSet<TKey, TValue> recordSet, CancellationToken cancellationToken)
             where TKey : class
             where TValue : class
         {
@@ -87,12 +122,20 @@ namespace Confluent.RestClient
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Post, requestUri)
                 .WithContent(recordSet, ContentTypeKafkaAvro);
 
-            return await ProcessRequest<PublishResponse>(request);
+            return await ProcessRequest<PublishResponse>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ConfluentResponse<ConsumerInstance>> CreateConsumerAsync(
-            string consumerGroupName, 
+            string consumerGroupName,
             CreateConsumerRequest createConsumerRequest)
+        {
+            return await CreateConsumerAsync(consumerGroupName, createConsumerRequest, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<ConsumerInstance>> CreateConsumerAsync(
+            string consumerGroupName,
+            CreateConsumerRequest createConsumerRequest,
+            CancellationToken cancellationToken)
         {
             string requestUri = string.Format("/consumers/{0}", consumerGroupName);
 
@@ -100,12 +143,21 @@ namespace Confluent.RestClient
                 .WithContent(createConsumerRequest, ContentTypeKafkaDefault)
                 .WithHostHeader(_clientSettings.KafkaBaseUrl);
 
-            return await ProcessRequest<ConsumerInstance>(request);
+            return await ProcessRequest<ConsumerInstance>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
             ConsumerInstance consumerInstance,
             string topic,
+            int? maxBytes = null)
+        {
+            return await ConsumeAsBinaryAsync(consumerInstance, topic, CancellationToken.None, maxBytes).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
+            ConsumerInstance consumerInstance,
+            string topic,
+            CancellationToken cancellationToken,
             int? maxBytes = null)
         {
             string requestUri = BuildConsumeRequestUri(topic, maxBytes);
@@ -114,12 +166,23 @@ namespace Confluent.RestClient
                 .WithContentType(ContentTypeKafkaBinary)
                 .WithHostHeader(consumerInstance.BaseUri);
 
-            return await ProcessRequest<List<BinaryMessage>>(request);
+            return await ProcessRequest<List<BinaryMessage>>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
             ConsumerInstance consumerInstance,
             string topic,
+            int? maxBytes = null)
+            where TKey : class
+            where TValue : class
+        {
+            return await ConsumeAsAvroAsync<TKey, TValue>(consumerInstance, topic, CancellationToken.None, maxBytes).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
+            ConsumerInstance consumerInstance,
+            string topic,
+            CancellationToken cancellationToken,
             int? maxBytes = null)
             where TKey : class
             where TValue : class
@@ -130,34 +193,44 @@ namespace Confluent.RestClient
                 .WithContentType(ContentTypeKafkaAvro)
                 .WithHostHeader(consumerInstance.BaseUri);
 
-            return await ProcessRequest<List<AvroMessage<TKey, TValue>>>(request);
+            return await ProcessRequest<List<AvroMessage<TKey, TValue>>>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ConfluentResponse<List<ConsumerOffset>>> CommitOffsetAsync(ConsumerInstance consumerInstance)
+        {
+            return await CommitOffsetAsync(consumerInstance, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse<List<ConsumerOffset>>> CommitOffsetAsync(ConsumerInstance consumerInstance, CancellationToken cancellationToken)
         {
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Post, "/offsets", consumerInstance.BaseUri)
                 .WithContentType(ContentTypeKafkaDefault)
                 .WithHostHeader(consumerInstance.BaseUri);
 
-            return await ProcessRequest<List<ConsumerOffset>>(request);
+            return await ProcessRequest<List<ConsumerOffset>>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ConfluentResponse> DeleteConsumerAsync(ConsumerInstance consumerInstance)
+        {
+            return await DeleteConsumerAsync(consumerInstance, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        public async Task<ConfluentResponse> DeleteConsumerAsync(ConsumerInstance consumerInstance, CancellationToken cancellationToken)
         {
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Delete, "", consumerInstance.BaseUri)
                 .WithContentType(ContentTypeKafkaDefault)
                 .WithHostHeader(consumerInstance.BaseUri);
 
-            var response = await SendRequest(request);
+            var response = await SendRequest(request, cancellationToken).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
             {
                 return ConfluentResponse.Success();
             }
 
-            return ConfluentResponse.Failed(await ReadResponseAs<Error>(response));
+            return ConfluentResponse.Failed(await ReadResponseAs<Error>(response).ConfigureAwait(false));
         }
-        
+
         private HttpRequestMessage CreateRequestMessage(HttpMethod method, string requestUri, string baseUri = null)
         {
             baseUri = (string.IsNullOrWhiteSpace(baseUri) ? _clientSettings.KafkaBaseUrl : baseUri).TrimEnd('/', '\\');
@@ -165,20 +238,20 @@ namespace Confluent.RestClient
 
             return new HttpRequestMessage(method, requestUri);
         }
-       
-        private async Task<ConfluentResponse<TResponse>> ProcessRequest<TResponse>(HttpRequestMessage request)
+
+        private async Task<ConfluentResponse<TResponse>> ProcessRequest<TResponse>(HttpRequestMessage request, CancellationToken cancellationToken)
             where TResponse : class
         {
-            var response = await SendRequest(request);
+            var response = await SendRequest(request, cancellationToken).ConfigureAwait(false);
 
             try
             {
                 if (response.IsSuccessStatusCode)
                 {
-                    return ConfluentResponse<TResponse>.Success(await ReadResponseAs<TResponse>(response));
+                    return ConfluentResponse<TResponse>.Success(await ReadResponseAs<TResponse>(response).ConfigureAwait(false));
                 }
 
-                return ConfluentResponse<TResponse>.Failed(await ReadResponseAs<Error>(response));
+                return ConfluentResponse<TResponse>.Failed(await ReadResponseAs<Error>(response).ConfigureAwait(false));
             }
             catch (Exception e)
             {
@@ -186,28 +259,35 @@ namespace Confluent.RestClient
             }
         }
 
-        private async Task<HttpResponseMessage> SendRequest(HttpRequestMessage request)
+        private async Task<HttpResponseMessage> SendRequest(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             try
             {
-                return await _client.SendAsync(request);
+                return await _client.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
             catch (TaskCanceledException ex)
             {
-                throw new ConfluentApiUnavailableException(
-                    "The operation has timed-out. The timeout period elapsed prior to completion of the operation or the server is not responding.",
-                    ex);
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                else
+                {
+                    throw new ConfluentApiUnavailableException(
+                        "The operation has timed-out. The timeout period elapsed prior to completion of the operation or the server is not responding.",
+                        ex);
+                }
             }
             catch (Exception e)
             {
                 throw new ConfluentApiUnavailableException("Failed to send request to confluent REST API", e);
-            }            
+            }
         }
 
         private async Task<TResponse> ReadResponseAs<TResponse>(HttpResponseMessage responseMessage)
             where TResponse : class
         {
-            using (Stream stream = await responseMessage.Content.ReadAsStreamAsync())
+            using (Stream stream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
             using (var streamReader = new StreamReader(stream))
             using (var reader = new JsonTextReader(streamReader))
             {

--- a/src/Confluent.RestClient/IConfluentClient.cs
+++ b/src/Confluent.RestClient/IConfluentClient.cs
@@ -185,7 +185,7 @@ namespace Confluent.RestClient
         Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
             ConsumerInstance consumerInstance,
             string topic,
-            int? maxBytes);
+            int maxBytes);
 
         /// <summary>
         /// Consume messages from a topic as binary (base 64 encoded string). 
@@ -199,7 +199,7 @@ namespace Confluent.RestClient
         Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
             ConsumerInstance consumerInstance,
             string topic,
-            int? maxBytes,
+            int maxBytes,
             CancellationToken cancellationToken);
 
 
@@ -242,7 +242,7 @@ namespace Confluent.RestClient
         Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
             ConsumerInstance consumerInstance,
             string topic,
-            int? maxBytes)
+            int maxBytes)
             where TKey : class
             where TValue : class;
 
@@ -258,7 +258,7 @@ namespace Confluent.RestClient
         Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
             ConsumerInstance consumerInstance,
             string topic,
-            int? maxBytes,
+            int maxBytes,
             CancellationToken cancellationToken)
             where TKey : class
             where TValue : class;

--- a/src/Confluent.RestClient/IConfluentClient.cs
+++ b/src/Confluent.RestClient/IConfluentClient.cs
@@ -156,12 +156,10 @@ namespace Confluent.RestClient
         /// </summary>
         /// <param name="consumerInstance">Consumer instance</param>
         /// <param name="topic">The topic to consume messages from</param>
-        /// <param name="maxBytes">The maximum number of bytes of un-encoded keys and values that should be included in the response</param>
         /// <returns>List of Binary messages</returns>
         Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
             ConsumerInstance consumerInstance,
-            string topic,
-            int? maxBytes = null);
+            string topic);
 
         /// <summary>
         /// Consume messages from a topic as binary (base 64 encoded string). 
@@ -170,13 +168,40 @@ namespace Confluent.RestClient
         /// <param name="consumerInstance">Consumer instance</param>
         /// <param name="topic">The topic to consume messages from</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns>List of Binary messages</returns>
+        Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
+            ConsumerInstance consumerInstance,
+            string topic,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Consume messages from a topic as binary (base 64 encoded string). 
+        /// If the consumer is not yet subscribed to the topic, this adds it as a subscriber, possibly causing a consumer rebalance
+        /// </summary>
+        /// <param name="consumerInstance">Consumer instance</param>
+        /// <param name="topic">The topic to consume messages from</param>
         /// <param name="maxBytes">The maximum number of bytes of un-encoded keys and values that should be included in the response</param>
         /// <returns>List of Binary messages</returns>
         Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
             ConsumerInstance consumerInstance,
             string topic,
-            CancellationToken cancellationToken,
-            int? maxBytes = null);
+            int? maxBytes);
+
+        /// <summary>
+        /// Consume messages from a topic as binary (base 64 encoded string). 
+        /// If the consumer is not yet subscribed to the topic, this adds it as a subscriber, possibly causing a consumer rebalance
+        /// </summary>
+        /// <param name="consumerInstance">Consumer instance</param>
+        /// <param name="topic">The topic to consume messages from</param>
+        /// <param name="maxBytes">The maximum number of bytes of un-encoded keys and values that should be included in the response</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns>List of Binary messages</returns>
+        Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
+            ConsumerInstance consumerInstance,
+            string topic,
+            int? maxBytes,
+            CancellationToken cancellationToken);
+
 
         /// <summary>
         /// Consume messages from a topic as Avro data 
@@ -184,12 +209,10 @@ namespace Confluent.RestClient
         /// </summary>
         /// <param name="consumerInstance">Consumer instance</param>
         /// <param name="topic">The topic to consume messages from</param>
-        /// <param name="maxBytes">The maximum number of bytes of un-encoded keys and values that should be included in the response</param>
         /// <returns>List of Avro messages</returns>
         Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
             ConsumerInstance consumerInstance,
-            string topic,
-            int? maxBytes = null)
+            string topic)
             where TKey : class
             where TValue : class;
 
@@ -200,13 +223,43 @@ namespace Confluent.RestClient
         /// <param name="consumerInstance">Consumer instance</param>
         /// <param name="topic">The topic to consume messages from</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns>List of Avro messages</returns>
+        Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
+            ConsumerInstance consumerInstance,
+            string topic,
+            CancellationToken cancellationToken)
+            where TKey : class
+            where TValue : class;
+
+        /// <summary>
+        /// Consume messages from a topic as Avro data 
+        /// If the consumer is not yet subscribed to the topic, this adds it as a subscriber, possibly causing a consumer rebalance
+        /// </summary>
+        /// <param name="consumerInstance">Consumer instance</param>
+        /// <param name="topic">The topic to consume messages from</param>
         /// <param name="maxBytes">The maximum number of bytes of un-encoded keys and values that should be included in the response</param>
         /// <returns>List of Avro messages</returns>
         Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
             ConsumerInstance consumerInstance,
             string topic,
-            CancellationToken cancellationToken,
-            int? maxBytes = null)
+            int? maxBytes)
+            where TKey : class
+            where TValue : class;
+
+        /// <summary>
+        /// Consume messages from a topic as Avro data 
+        /// If the consumer is not yet subscribed to the topic, this adds it as a subscriber, possibly causing a consumer rebalance
+        /// </summary>
+        /// <param name="consumerInstance">Consumer instance</param>
+        /// <param name="topic">The topic to consume messages from</param>
+        /// <param name="maxBytes">The maximum number of bytes of un-encoded keys and values that should be included in the response</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns>List of Avro messages</returns>
+        Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
+            ConsumerInstance consumerInstance,
+            string topic,
+            int? maxBytes,
+            CancellationToken cancellationToken)
             where TKey : class
             where TValue : class;
 

--- a/src/Confluent.RestClient/IConfluentClient.cs
+++ b/src/Confluent.RestClient/IConfluentClient.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Confluent.RestClient.Model;
+using System.Threading;
 
 namespace Confluent.RestClient
 {
@@ -18,6 +19,13 @@ namespace Confluent.RestClient
         Task<ConfluentResponse<List<string>>> GetTopicsAsync();
 
         /// <summary>
+        /// Get a list of Kafka topics
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns></returns>
+        Task<ConfluentResponse<List<string>>> GetTopicsAsync(CancellationToken cancellationToken);
+
+        /// <summary>
         /// Get metadata about a specific topic
         /// </summary>
         /// <param name="topicName">Name of the topic to get metadata about</param>
@@ -25,11 +33,27 @@ namespace Confluent.RestClient
         Task<ConfluentResponse<Topic>> GetTopicMetadataAsync(string topicName);
 
         /// <summary>
+        /// Get metadata about a specific topic
+        /// </summary>
+        /// <param name="topicName">Name of the topic to get metadata about</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns></returns>
+        Task<ConfluentResponse<Topic>> GetTopicMetadataAsync(string topicName, CancellationToken cancellationToken);
+
+        /// <summary>
         /// The partitions resource provides per-partition metadata, including the current leaders and replicas for each partition
         /// </summary>
         /// <param name="topicName">Name of the topic to get metadata about</param>
         /// <returns></returns>
         Task<ConfluentResponse<List<Partition>>> GetTopicPartitionsAsync(string topicName);
+
+        /// <summary>
+        /// The partitions resource provides per-partition metadata, including the current leaders and replicas for each partition
+        /// </summary>
+        /// <param name="topicName">Name of the topic to get metadata about</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns></returns>
+        Task<ConfluentResponse<List<Partition>>> GetTopicPartitionsAsync(string topicName, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get metadata about a single partition in the topic
@@ -40,6 +64,15 @@ namespace Confluent.RestClient
         Task<ConfluentResponse<Partition>> GetTopicPartitionAsync(string topicName, int partitionId);
 
         /// <summary>
+        /// Get metadata about a single partition in the topic
+        /// </summary>
+        /// <param name="topicName">Name of the topic</param>
+        /// <param name="partitionId">ID of the partition to inspect</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns></returns>
+        Task<ConfluentResponse<Partition>> GetTopicPartitionAsync(string topicName, int partitionId, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Create a new consumer instance in the consumer group
         /// Note that the response includes a URL including the host since the consumer is stateful and tied to a specific REST proxy instance. 
         /// Subsequent examples in this section use a `Host` header for this specific REST proxy instance
@@ -48,8 +81,22 @@ namespace Confluent.RestClient
         /// <param name="createConsumerRequest"></param>
         /// <returns></returns>
         Task<ConfluentResponse<ConsumerInstance>> CreateConsumerAsync(
-            string consumerGroupName, 
+            string consumerGroupName,
             CreateConsumerRequest createConsumerRequest);
+
+        /// <summary>
+        /// Create a new consumer instance in the consumer group
+        /// Note that the response includes a URL including the host since the consumer is stateful and tied to a specific REST proxy instance. 
+        /// Subsequent examples in this section use a `Host` header for this specific REST proxy instance
+        /// </summary>
+        /// <param name="consumerGroupName">The name of the consumer group to join</param>
+        /// <param name="createConsumerRequest"></param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns></returns>
+        Task<ConfluentResponse<ConsumerInstance>> CreateConsumerAsync(
+            string consumerGroupName,
+            CreateConsumerRequest createConsumerRequest,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Produce binary messages to a topic, optionally specifying keys or partitions for the messages
@@ -62,6 +109,18 @@ namespace Confluent.RestClient
             BinaryRecordSet recordSet);
 
         /// <summary>
+        /// Produce binary messages to a topic, optionally specifying keys or partitions for the messages
+        /// </summary>
+        /// <param name="topicName">Name of the topic to produce the messages to</param>
+        /// <param name="recordSet">Binary record set</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns></returns>
+        Task<ConfluentResponse<PublishResponse>> PublishAsBinaryAsync(
+            string topicName,
+            BinaryRecordSet recordSet,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Produce Avro messages to a topic, optionally specifying keys or partitions for the messages
         /// </summary>
         /// <typeparam name="TKey">Type of the key</typeparam>
@@ -70,8 +129,24 @@ namespace Confluent.RestClient
         /// <param name="recordSet"></param>
         /// <returns></returns>
         Task<ConfluentResponse<PublishResponse>> PublishAsAvroAsync<TKey, TValue>(
-            string topicName, 
+            string topicName,
             AvroRecordSet<TKey, TValue> recordSet)
+            where TKey : class
+            where TValue : class;
+
+        /// <summary>
+        /// Produce Avro messages to a topic, optionally specifying keys or partitions for the messages
+        /// </summary>
+        /// <typeparam name="TKey">Type of the key</typeparam>
+        /// <typeparam name="TValue">Type of the value</typeparam>
+        /// <param name="topicName">Name of the topic to produce the messages to</param>
+        /// <param name="recordSet"></param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns></returns>
+        Task<ConfluentResponse<PublishResponse>> PublishAsAvroAsync<TKey, TValue>(
+            string topicName,
+            AvroRecordSet<TKey, TValue> recordSet,
+            CancellationToken cancellationToken)
             where TKey : class
             where TValue : class;
 
@@ -86,6 +161,21 @@ namespace Confluent.RestClient
         Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
             ConsumerInstance consumerInstance,
             string topic,
+            int? maxBytes = null);
+
+        /// <summary>
+        /// Consume messages from a topic as binary (base 64 encoded string). 
+        /// If the consumer is not yet subscribed to the topic, this adds it as a subscriber, possibly causing a consumer rebalance
+        /// </summary>
+        /// <param name="consumerInstance">Consumer instance</param>
+        /// <param name="topic">The topic to consume messages from</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <param name="maxBytes">The maximum number of bytes of un-encoded keys and values that should be included in the response</param>
+        /// <returns>List of Binary messages</returns>
+        Task<ConfluentResponse<List<BinaryMessage>>> ConsumeAsBinaryAsync(
+            ConsumerInstance consumerInstance,
+            string topic,
+            CancellationToken cancellationToken,
             int? maxBytes = null);
 
         /// <summary>
@@ -104,6 +194,23 @@ namespace Confluent.RestClient
             where TValue : class;
 
         /// <summary>
+        /// Consume messages from a topic as Avro data 
+        /// If the consumer is not yet subscribed to the topic, this adds it as a subscriber, possibly causing a consumer rebalance
+        /// </summary>
+        /// <param name="consumerInstance">Consumer instance</param>
+        /// <param name="topic">The topic to consume messages from</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <param name="maxBytes">The maximum number of bytes of un-encoded keys and values that should be included in the response</param>
+        /// <returns>List of Avro messages</returns>
+        Task<ConfluentResponse<List<AvroMessage<TKey, TValue>>>> ConsumeAsAvroAsync<TKey, TValue>(
+            ConsumerInstance consumerInstance,
+            string topic,
+            CancellationToken cancellationToken,
+            int? maxBytes = null)
+            where TKey : class
+            where TValue : class;
+
+        /// <summary>
         /// Commit offsets for the consumer
         /// Note that this request must be made to the specific REST proxy instance holding the consumer instance (using `Host` header)
         /// </summary>
@@ -112,11 +219,29 @@ namespace Confluent.RestClient
         Task<ConfluentResponse<List<ConsumerOffset>>> CommitOffsetAsync(ConsumerInstance consumerInstance);
 
         /// <summary>
+        /// Commit offsets for the consumer
+        /// Note that this request must be made to the specific REST proxy instance holding the consumer instance (using `Host` header)
+        /// </summary>
+        /// <param name="consumerInstance">Consumer instance</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns>Returns a list of the partitions with the committed offsets</returns>
+        Task<ConfluentResponse<List<ConsumerOffset>>> CommitOffsetAsync(ConsumerInstance consumerInstance, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Destroy the consumer instance
         /// Note that this request must be made to the specific REST proxy instance holding the consumer instance (using `Host` header)
         /// </summary>
         /// <param name="consumerInstance">Consumer instance</param>
         /// <returns></returns>
         Task<ConfluentResponse> DeleteConsumerAsync(ConsumerInstance consumerInstance);
+
+        /// <summary>
+        /// Destroy the consumer instance
+        /// Note that this request must be made to the specific REST proxy instance holding the consumer instance (using `Host` header)
+        /// </summary>
+        /// <param name="consumerInstance">Consumer instance</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the operation</param>
+        /// <returns></returns>
+        Task<ConfluentResponse> DeleteConsumerAsync(ConsumerInstance consumerInstance, CancellationToken cancellationToken);
     }
 }

--- a/src/Confluent.TestHarness/TestApp.cs
+++ b/src/Confluent.TestHarness/TestApp.cs
@@ -191,21 +191,44 @@ namespace Confluent.TestHarness
 
         private void buttonConsumerBinary_Click(object sender, EventArgs e)
         {
-            Run(() => _confluentClient.ConsumeAsBinaryAsync(new ConsumerInstance
+            var maxBytes = GetMaxBytesOrNull();
+            if (maxBytes.HasValue)
             {
-                BaseUri = string.Format("{0}/consumers/{1}/instances/{2}", _baseUrl, textBoxConsumerGroup.Text, textBoxConsumerId.Text),
-                InstanceId = textBoxConsumerId.Text
-            }, textBoxTopic.Text, GetMaxBytesOrNull()).Result);
+                Run(() => _confluentClient.ConsumeAsBinaryAsync(new ConsumerInstance
+                {
+                    BaseUri = string.Format("{0}/consumers/{1}/instances/{2}", _baseUrl, textBoxConsumerGroup.Text, textBoxConsumerId.Text),
+                    InstanceId = textBoxConsumerId.Text
+                }, textBoxTopic.Text, maxBytes.Value).Result);
+            }
+            else
+            {
+                Run(() => _confluentClient.ConsumeAsBinaryAsync(new ConsumerInstance
+                {
+                    BaseUri = string.Format("{0}/consumers/{1}/instances/{2}", _baseUrl, textBoxConsumerGroup.Text, textBoxConsumerId.Text),
+                    InstanceId = textBoxConsumerId.Text
+                }, textBoxTopic.Text).Result);
+            }
         }
 
         private void buttonConsumeAvro_Click(object sender, EventArgs e)
         {
-            Run(() => _confluentClient.ConsumeAsAvroAsync<string, Person>(new ConsumerInstance
+            var maxBytes = GetMaxBytesOrNull();
+            if (maxBytes.HasValue)
             {
-                BaseUri = string.Format("{0}/consumers/{1}/instances/{2}", _baseUrl, textBoxConsumerGroup.Text, textBoxConsumerId.Text),
-                InstanceId = textBoxConsumerId.Text
-            }, textBoxTopic.Text, GetMaxBytesOrNull()).Result);
-
+                Run(() => _confluentClient.ConsumeAsAvroAsync<string, Person>(new ConsumerInstance
+                {
+                    BaseUri = string.Format("{0}/consumers/{1}/instances/{2}", _baseUrl, textBoxConsumerGroup.Text, textBoxConsumerId.Text),
+                    InstanceId = textBoxConsumerId.Text
+                }, textBoxTopic.Text, maxBytes.Value).Result);
+            }
+            else
+            {
+                Run(() => _confluentClient.ConsumeAsAvroAsync<string, Person>(new ConsumerInstance
+                {
+                    BaseUri = string.Format("{0}/consumers/{1}/instances/{2}", _baseUrl, textBoxConsumerGroup.Text, textBoxConsumerId.Text),
+                    InstanceId = textBoxConsumerId.Text
+                }, textBoxTopic.Text).Result);
+            }
         }
 
         private void buttonCommitOffset_Click(object sender, EventArgs e)


### PR DESCRIPTION
Added an overload to each async operation on `IConfluentClient` that now
takes a `CancellationToken` so that the caller can cancel any in progress
requests. *Note that the current behavior in the `SendRequest` method
converts the `TaskCancelledException` into a
`ConfluentApiUnavailableException` where it states (via the message) that
it was due to timeout. I changed this to allow an explicit user
initiated cancel to propagate the `TaskCanceledException` and the timeout
will continue to convert to the confluent exception.

Added an explicit `ConfigureAwait(false)` call on all awaited calls - this
will help to ensure that the callback doesn't cause a deadlock if the
caller has requirements on callback context (e.g. GUI apps, ASP.NET)
https://msdn.microsoft.com/en-us/magazine/jj991977.aspx
